### PR TITLE
Update jws-3.0.js to remove hextorstr() calls

### DIFF
--- a/jws-3.0.js
+++ b/jws-3.0.js
@@ -437,7 +437,7 @@ KJUR.jws.JWS.sign = function(alg, sHeader, sPayload, key, pass) {
     if (sigAlg.substr(0, 4) == "Hmac") {
 	if (key === undefined)
 	    throw "hexadecimal key shall be specified for HMAC";
-	var mac = new KJUR.crypto.Mac({'alg': sigAlg, 'pass': hextorstr(key)});
+	var mac = new KJUR.crypto.Mac({'alg': sigAlg, 'pass': key});
 	mac.updateString(uSignatureInput);
 	hSig = mac.doFinal();
     } else if (sigAlg.indexOf("withECDSA") != -1) {
@@ -499,7 +499,7 @@ KJUR.jws.JWS.verify = function(sJWS, key) {
     } else if (sigAlg.substr(0, 4) == "Hmac") {
 	if (key === undefined)
 	    throw "hexadecimal key shall be specified for HMAC";
-	var mac = new KJUR.crypto.Mac({'alg': sigAlg, 'pass': hextorstr(key)});
+	var mac = new KJUR.crypto.Mac({'alg': sigAlg, 'pass': key});
 	mac.updateString(uSignatureInput);
 	hSig2 = mac.doFinal();
 	return hSig == hSig2;


### PR DESCRIPTION
This additional conversion of the pass value with hextorstr() makes the signature not decodable by other libraries, as they do not perform this hex conversion. Not sure of further impact, but at a minimum this is need to allow these hmac functions to work predictably.

There was an issue opened for this, but it was (and still is at this time) still left as closed and wontfix.
https://github.com/kjur/jsjws/issues/17